### PR TITLE
Decode insecure sessions with sessionOptions.secure = false

### DIFF
--- a/fullmoon.lua
+++ b/fullmoon.lua
@@ -1317,7 +1317,7 @@ local function getSession()
     LogWarn("invalid session crypto hash: "..hash)
     return {}
   end
-  if DecodeBase64(sig) ~= GetCryptoHash(hash, msg, sopts.secret) then
+  if DecodeBase64(sig) ~= GetCryptoHash(hash, msg, sopts.secret or "") then
     LogWarn("invalid session signature: "..sig)
     return {}
   end
@@ -1470,7 +1470,7 @@ fm.test = {
   reqenv = reqenv, route2regex = route2regex, routes = routes,
   matchRoute = matchRoute, handleRequest = handleRequest, getRequest = getRequest,
   headerMap = headerMap, detectType = detectType, matchCondition = matchCondition,
-  setSession = setSession,
+  setSession = setSession, getSession = getSession
 }
 
 function fm.run(opts)

--- a/test.lua
+++ b/test.lua
@@ -14,6 +14,7 @@ local getRequest = fm.test.getRequest
 local detectType = fm.test.detectType
 local matchRoute = fm.test.matchRoute
 local setSession = fm.test.setSession
+local getSession = fm.test.getSession
 local route2regex = fm.test.route2regex
 local handleRequest = fm.test.handleRequest
 local matchCondition = fm.test.matchCondition
@@ -607,6 +608,11 @@ do local cookie, value, options
     setSession({a=""})
     is(cookie, "fullmoon_session")
     is(value, "e2E9IiJ9.lua.SHA256.AYDGTB6O7W4ohlbpRtgvY2NiDFUdS1efkd0ZpROoL+Q=")
+    
+    GetCookie = function(c) return value end
+    fm.sessionOptions.secret = false
+    local session = getSession()
+    is(session.a, "", "getSession works with secret set to false")
   end
 end
 


### PR DESCRIPTION
The session documentation states that cookies can be left insecure by setting `sessionOptions.secure` to either `""` or `false`. However, trying to decode a session cookie with `sessionOptions.secure = false` throws an error:

```
/zip/.lua/fullmoon.lua:1320: bad argument #3 to 'GetCryptoHash' (string expected, got boolean)
```

This commit fixes that by passing `""` instead of `false` to `GetCryptoHash` in `getSession`.